### PR TITLE
Add support for Red Hat-based distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Installs [cmake](http://www.cmake.org/), the cross-platform, open-source build s
 
 The following platforms are supported by this cookbook, meaning that the recipes run on these platforms without error:
 
-* Ubuntu
+* Ubuntu/Debian
+* Fedora/CentOS/RedHat Enterprise Linux
 
 # RECIPES
 
 * `cmake`,         Default recipe
-
 
 # USAGE
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,11 @@ maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Install cmake"
 version           "0.1.0"
-supports          "ubuntu"
 
 recipe "default", "Install default cmake support"
+
+%w{ debian ubuntu redhat centos fedora }.each do |os|
+  supports os
+end
+
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,4 +3,9 @@
 # Recipe:: default
 #
 
-package "cmake"
+case node[:platform]
+when "centos","fedora","redhat"
+  package "cmake28"
+when "ubuntu","debian"
+  package "cmake"
+end


### PR DESCRIPTION
Modifications made to support RedHat-based distributions. I've omitted support for CMake 2.6 and instead the recipe just installs CMake 2.8
